### PR TITLE
Scale HPLW cost function by sqrt(n).

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The C library is tested using using the
 [check](http://libcheck.github.io/check/) library. The test suite can be built
 using the following command:
 
-	$ gcc -std=c99 -g -o run_tests -Irig_c_sa tests/*.c rig_c_sa/*.c -lm $(pkg-config --cflags --libs check)
+	$ gcc -std=c99 -g -o run_tests -Irig_c_sa tests/*.c rig_c_sa/sa.c -lm $(pkg-config --cflags --libs check)
 
 The test suite should then be run under valgrind to ensure any memory leaks are found:
 

--- a/rig_c_sa/sa.c
+++ b/rig_c_sa/sa.c
@@ -531,7 +531,7 @@ double sa_get_net_cost(sa_state_t *state, sa_net_t *net) {
 		// From this we can work out the bounding box size and thus the HPWL.
 		bbox_width = (int)state->width - max_delta_x;
 		bbox_height = (int)state->height - max_delta_y;
-		return (bbox_width + bbox_height) * net->weight;
+		return sqrt(net->num_vertices) * (bbox_width + bbox_height) * net->weight;
 	} else {
 		// Non-toriodal network: Compute bounding box
 		min_x = net->vertices[0]->x;
@@ -550,7 +550,7 @@ double sa_get_net_cost(sa_state_t *state, sa_net_t *net) {
 		}
 		
 		// Compute weighted HPWL
-		return ((max_x - min_x) + (max_y - min_y)) * net->weight;
+		return sqrt(net->num_vertices) * ((max_x - min_x) + (max_y - min_y)) * net->weight;
 	}
 }
 

--- a/tests/test_sa_algorithm.c
+++ b/tests/test_sa_algorithm.c
@@ -121,14 +121,14 @@ START_TEST (test_get_net_cost)
 	
 	// Without wrap-around we have a 17x8 boundingbox at weight 2.0.
 	s->has_wrap_around_links = false;
-	ck_assert_msg(sa_get_net_cost(s, n) == (17.0 + 8.0) * 2.0,
-	              "%f != %f", sa_get_net_cost(s, n), (17.0 + 8.0) * 2.0);
+	ck_assert_msg(sa_get_net_cost(s, n) == sqrt(4) * (17.0 + 8.0) * 2.0,
+	              "%f != %f", sa_get_net_cost(s, n), sqrt(4) * (17.0 + 8.0) * 2.0);
 	
 	// With wrap-around the bounding box wraps giving a 8x4 bounding box at
 	// weight 2.0
 	s->has_wrap_around_links = true;
-	ck_assert_msg(sa_get_net_cost(s, n) == (8.0 + 4.0) * 2.0,
-	              "%f != %f", sa_get_net_cost(s, n), (8.0 + 4.0) * 2.0);
+	ck_assert_msg(sa_get_net_cost(s, n) == sqrt(4) * (8.0 + 4.0) * 2.0,
+	              "%f != %f", sa_get_net_cost(s, n), sqrt(4) * (8.0 + 4.0) * 2.0);
 	
 	/* Set alternative vertex positions. Note that:
 	 * * The wrapping and non-wrapping bounding box is the same
@@ -153,11 +153,11 @@ START_TEST (test_get_net_cost)
 	
 	// Without wrap-around we have a 2x2 boundingbox at weight 2.0.
 	s->has_wrap_around_links = false;
-	ck_assert_msg(sa_get_net_cost(s, n) == (2.0 + 2.0) * 2.0,
-	              "%f != %f", sa_get_net_cost(s, n), (2.0 + 2.0) * 2.0);
+	ck_assert_msg(sa_get_net_cost(s, n) == sqrt(4) * (2.0 + 2.0) * 2.0,
+	              "%f != %f", sa_get_net_cost(s, n), sqrt(4) * (2.0 + 2.0) * 2.0);
 	s->has_wrap_around_links = true;
-	ck_assert_msg(sa_get_net_cost(s, n) == (2.0 + 2.0) * 2.0,
-	              "%f != %f", sa_get_net_cost(s, n), (2.0 + 2.0) * 2.0);
+	ck_assert_msg(sa_get_net_cost(s, n) == sqrt(4) * (2.0 + 2.0) * 2.0,
+	              "%f != %f", sa_get_net_cost(s, n), sqrt(4) * (2.0 + 2.0) * 2.0);
 	
 	sa_free(s);
 }
@@ -207,7 +207,8 @@ START_TEST (test_get_swap_cost)
 	
 	// Nets x and y should have their cost reduced by 1 for a total cost saving
 	// of 2.
-	ck_assert(sa_get_swap_cost(s, 0, 0, va, 1, 0, vb) == -2.0);
+	double swap_cost = sa_get_swap_cost(s, 0, 0, va, 1, 0, vb);
+	ck_assert(abs(swap_cost - (sqrt(2) * -2.0)) < 0.001);
 	
 	sa_free(s);
 }
@@ -344,7 +345,7 @@ START_TEST (test_step_bad_cost)
 			num_swapped++;
 			
 			// Cost should have increased
-			ck_assert(cost == 1.0);
+			ck_assert(cost == sqrt(2) * 1.0);
 			
 			// Vertices should have moved
 			ck_assert(sa_get_chip_vertex(s, 0, 0) == NULL);
@@ -451,7 +452,7 @@ START_TEST (test_run_steps)
 	ck_assert(cost_delta_sd < 1.0);
 	
 	// The cost change overall should drop from 6 to 1.
-	ck_assert_msg(cost_delta == -5.0, "%f == %f", cost_delta, -5.0);
+	ck_assert_msg(abs(cost_delta - (sqrt(2) * -5.0)) < 0.001, "%f == %f", cost_delta, sqrt(2) * -5.0);
 	
 	sa_free(s);
 }


### PR DESCRIPTION
The HPWL cost function under-estimates net cost for nets with fan-out greater than 3. The error grows at a rate proportional to sqrt(n). By scaling the cost by this amount, the error is reduced for larger-fan-out nets. See "The largest minimal rectilinear steiner trees for a set of n points enclosed in a rectangle with given perimeter" Chung, FRK and Hwang, FK 1979.

The error of HPWLxy (the old cost model) and sqrt(n)*HPWLxy (the cost model in this change) can be seen to be smaller as fan-out grows. A plot is shown below taken from some experiments in my thesis where random nets are generated and and the cost estimated by these cost functions is compared with the cost resulting from running the NER routing algorithm.

![Net cost functions](https://cloud.githubusercontent.com/assets/193514/16109370/6655c70c-33a0-11e6-8a95-f8a1d8c3a1e3.png)

Note that the non-zero error here can be partly attributed to the sqrt(n) error only being correct for "very large" fan outs and also due to the NER router not actually producing perfectly minimal routes... Real-world implementations used a LUT of scaling factors up to about fan-out-50. Due to time/laziness constraints I've not explored this yet.

As an aside, the 'star' cost function (seen blasting off the top of the plot) was considered in the `distance-cost` branch and found to produce considerably worse placement results.
