### PR TITLE
Cache net bounding boxes to improve performance for high-fan-out nets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The C library is tested using using the
 [check](http://libcheck.github.io/check/) library. The test suite can be built
 using the following command:
 
-	$ gcc -std=c99 -g -o run_tests -Irig_c_sa tests/*.c rig_c_sa/*.c -lm $(pkg-config --cflags --libs check)
+	$ gcc -std=c99 -g -o run_tests -Irig_c_sa tests/*.c rig_c_sa/sa.c -lm $(pkg-config --cflags --libs check)
 
 The test suite should then be run under valgrind to ensure any memory leaks are found:
 

--- a/rig_c_sa/cffi_compile.py
+++ b/rig_c_sa/cffi_compile.py
@@ -22,7 +22,7 @@ ffi.set_source(
             size_t i;
             double total = 0.0;
             for (i = 0; i < state->num_nets; i++)
-                total += sa_get_net_cost(state, state->nets[i]);
+                total += sa_get_net_cost(state, state->nets[i], sa_false, -1,-1,-1,-1);
             return total;
         }
     """,

--- a/rig_c_sa/sa.c
+++ b/rig_c_sa/sa.c
@@ -531,7 +531,7 @@ double sa_get_net_cost(sa_state_t *state, sa_net_t *net) {
 		// From this we can work out the bounding box size and thus the HPWL.
 		bbox_width = (int)state->width - max_delta_x;
 		bbox_height = (int)state->height - max_delta_y;
-		return (bbox_width + bbox_height) * net->weight;
+		return sqrt(net->num_vertices) * (bbox_width + bbox_height) * net->weight;
 	} else {
 		// Non-toriodal network: Compute bounding box
 		min_x = net->vertices[0]->x;
@@ -550,7 +550,7 @@ double sa_get_net_cost(sa_state_t *state, sa_net_t *net) {
 		}
 		
 		// Compute weighted HPWL
-		return ((max_x - min_x) + (max_y - min_y)) * net->weight;
+		return sqrt(net->num_vertices) * ((max_x - min_x) + (max_y - min_y)) * net->weight;
 	}
 }
 

--- a/tests/test_sa_algorithm.c
+++ b/tests/test_sa_algorithm.c
@@ -121,14 +121,14 @@ START_TEST (test_get_net_cost)
 	
 	// Without wrap-around we have a 17x8 boundingbox at weight 2.0.
 	s->has_wrap_around_links = false;
-	ck_assert_msg(sa_get_net_cost(s, n) == (17.0 + 8.0) * 2.0,
-	              "%f != %f", sa_get_net_cost(s, n), (17.0 + 8.0) * 2.0);
+	ck_assert_msg(sa_get_net_cost(s, n) == sqrt(4) * (17.0 + 8.0) * 2.0,
+	              "%f != %f", sa_get_net_cost(s, n), sqrt(4) * (17.0 + 8.0) * 2.0);
 	
 	// With wrap-around the bounding box wraps giving a 8x4 bounding box at
 	// weight 2.0
 	s->has_wrap_around_links = true;
-	ck_assert_msg(sa_get_net_cost(s, n) == (8.0 + 4.0) * 2.0,
-	              "%f != %f", sa_get_net_cost(s, n), (8.0 + 4.0) * 2.0);
+	ck_assert_msg(sa_get_net_cost(s, n) == sqrt(4) * (8.0 + 4.0) * 2.0,
+	              "%f != %f", sa_get_net_cost(s, n), sqrt(4) * (8.0 + 4.0) * 2.0);
 	
 	/* Set alternative vertex positions. Note that:
 	 * * The wrapping and non-wrapping bounding box is the same
@@ -153,11 +153,11 @@ START_TEST (test_get_net_cost)
 	
 	// Without wrap-around we have a 2x2 boundingbox at weight 2.0.
 	s->has_wrap_around_links = false;
-	ck_assert_msg(sa_get_net_cost(s, n) == (2.0 + 2.0) * 2.0,
-	              "%f != %f", sa_get_net_cost(s, n), (2.0 + 2.0) * 2.0);
+	ck_assert_msg(sa_get_net_cost(s, n) == sqrt(4) * (2.0 + 2.0) * 2.0,
+	              "%f != %f", sa_get_net_cost(s, n), sqrt(4) * (2.0 + 2.0) * 2.0);
 	s->has_wrap_around_links = true;
-	ck_assert_msg(sa_get_net_cost(s, n) == (2.0 + 2.0) * 2.0,
-	              "%f != %f", sa_get_net_cost(s, n), (2.0 + 2.0) * 2.0);
+	ck_assert_msg(sa_get_net_cost(s, n) == sqrt(4) * (2.0 + 2.0) * 2.0,
+	              "%f != %f", sa_get_net_cost(s, n), sqrt(4) * (2.0 + 2.0) * 2.0);
 	
 	sa_free(s);
 }
@@ -207,7 +207,8 @@ START_TEST (test_get_swap_cost)
 	
 	// Nets x and y should have their cost reduced by 1 for a total cost saving
 	// of 2.
-	ck_assert(sa_get_swap_cost(s, 0, 0, va, 1, 0, vb) == -2.0);
+	double swap_cost = sa_get_swap_cost(s, 0, 0, va, 1, 0, vb);
+	ck_assert(abs(swap_cost - (sqrt(2) * -2.0)) < 0.001);
 	
 	sa_free(s);
 }
@@ -344,7 +345,7 @@ START_TEST (test_step_bad_cost)
 			num_swapped++;
 			
 			// Cost should have increased
-			ck_assert(cost == 1.0);
+			ck_assert(cost == sqrt(2) * 1.0);
 			
 			// Vertices should have moved
 			ck_assert(sa_get_chip_vertex(s, 0, 0) == NULL);
@@ -451,7 +452,7 @@ START_TEST (test_run_steps)
 	ck_assert(cost_delta_sd < 1.0);
 	
 	// The cost change overall should drop from 6 to 1.
-	ck_assert_msg(cost_delta == -5.0, "%f == %f", cost_delta, -5.0);
+	ck_assert_msg(abs(cost_delta - (sqrt(2) * -5.0)) < 0.001, "%f == %f", cost_delta, sqrt(2) * -5.0);
 	
 	sa_free(s);
 }

--- a/tests/test_sa_state.c
+++ b/tests/test_sa_state.c
@@ -111,6 +111,14 @@ START_TEST (test_constructors)
 		s->nets[i] = n;
 		
 		ck_assert(n->num_vertices == nv - i);
+		ck_assert_int_eq(n->bbox.x1, -1);
+		ck_assert_int_eq(n->bbox.x2, -1);
+		ck_assert_int_eq(n->bbox.y1, -1);
+		ck_assert_int_eq(n->bbox.y2, -1);
+		ck_assert_int_eq(n->last_bbox.x1, -1);
+		ck_assert_int_eq(n->last_bbox.x2, -1);
+		ck_assert_int_eq(n->last_bbox.y1, -1);
+		ck_assert_int_eq(n->last_bbox.y2, -1);
 		n->weight = i + 1.0;
 		
 		// Attempt to add connections between involved vertices


### PR DESCRIPTION
Builds on #4 and should be merged afterwards.

Rather than recomputing the bounding box of every impacted net _twice_ on every swap in order to compute the cost of the net, store the bounding box and only recompute it when it changes. For simplicity this implementation is rather conservative and actually regenerates the bounding box more often than strictly necessary.

For low-fan-out nets this has little performance impact. For nets with really silly fan-outs, I've seen algorithm execution times 2-4x quicker.

A work-in-progress experiment for my thesis takes 16,384 vertices in a 128x128 2D grid interconnected by nets with a simple 2D gaussian connectivity pattern. The pink/purple line in the plot below shows the runtime of the SA algorithm as the fan-out of the nets is ramped up (NB: log-log plot). The black dots show the runtime of the old version on the same graph. Note that I got bored once the runtime reached an hour or so...

![Fan out scaling experiments](https://cloud.githubusercontent.com/assets/193514/16123593/7dffd418-33e3-11e6-8baa-0b01c9b51d98.png)

The plot below shows how the 'quality' of the placement decreases with fan out. Quality here is measured as the routing congestion as a proportion of the congestion produced by a manual placement. 1.0 means as-good-as-manual, higher values are better!

![Fan out quality experiment](https://cloud.githubusercontent.com/assets/193514/16123957/cdb68dca-33e4-11e6-8bfe-c57d730468ff.png)
